### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/webflux/src/main/java/com/nurkiewicz/webflux/demo/feed/RedisRepository.java
+++ b/webflux/src/main/java/com/nurkiewicz/webflux/demo/feed/RedisRepository.java
@@ -1,9 +1,9 @@
 package com.nurkiewicz.webflux.demo.feed;
 
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
-@Component
+@Repository
 public class RedisRepository {
 
     private final ReactiveStringRedisTemplate redis;


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code.

A Spring bean in the persistence layer should be annotated using @repository instead of @component annotation.
@repository annotation is a specialization of @component in persistence layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @repository is a better choice.