### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/webflux/src/main/java/com/nurkiewicz/webflux/demo/security/SecretService.java
+++ b/webflux/src/main/java/com/nurkiewicz/webflux/demo/security/SecretService.java
@@ -15,9 +15,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class SecretService {
 
 	private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code.

A Spring bean in the service layer should be annotated using @service instead of @component annotation.
@service annotation is a specialization of @component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @service is a better choice.